### PR TITLE
CI Fix build cache restoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ on:
 
 jobs:
   workflows:
-    uses: hassio-addons/workflows/.github/workflows/addon-ci.yaml@main
+    uses: BenoitAnastay/workflows/.github/workflows/addon-ci.yaml@main


### PR DESCRIPTION
The restoration of build cache was failling because the repository name wasn't lower case