### PR TITLE
Slug update

### DIFF
--- a/paperless-ngx/config.yaml
+++ b/paperless-ngx/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: Paperless-ngx
 version: dev
-slug: paperless-ngx
+slug: paperless_ngx
 url: https://github.com/paperless-ngx/paperless-ngx
 init: false
 ingress: true


### PR DESCRIPTION
Update slug to avoid usage of hyphen.
HA partial backup doesn't allow to use addons with hyphen and forces to update the slug to underscore. When I do that, the job finishes, but doesn't pick up any addon.  It is advised to update the slug to bring back the partial backup compatibility