### PR TITLE
🐛 Set dummy Origin for ingress

### DIFF
--- a/paperless-ngx/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/paperless-ngx/rootfs/etc/nginx/templates/ingress.gtpl
@@ -17,6 +17,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header Origin "http://ingress.local";
         add_header Referrer-Policy "strict-origin-when-cross-origin";
     }
 

--- a/paperless-ngx/rootfs/etc/s6-overlay/s6-rc.d/init-paperless/run
+++ b/paperless-ngx/rootfs/etc/s6-overlay/s6-rc.d/init-paperless/run
@@ -44,6 +44,7 @@ addon_port=$(bashio::addon.port 80)
 
 # Get all possible URLs
 result=$(bashio::api.supervisor GET /core/api/config true || true)
+urls+=("ingress.local")
 urls+=("$(bashio::info.hostname).local")
 urls+=("$(bashio::info.hostname)")
 urls+=("$(bashio::jq "$result" '.internal_url' | cut -d'/' -f3 | cut -d':' -f1)")


### PR DESCRIPTION
Since the ingress endpoint is only accessible by HA core container I decided to set a dummy origin to fix the issue with the last release of HA.

Any CSRF issue related to ingress should now be fixed 