### PR TITLE
🐛 fix: HTTP Headers removed, causing CSRF faillure #169

### DIFF
--- a/paperless-ngx/rootfs/etc/nginx/templates/direct.gtpl
+++ b/paperless-ngx/rootfs/etc/nginx/templates/direct.gtpl
@@ -8,7 +8,6 @@ server {
     include /etc/nginx/includes/server_params.conf;
 
     location / {
-        proxy_pass_request_headers off;
         # Adjust host and port as required.
         proxy_pass http://localhost:8000/;
 


### PR DESCRIPTION
All header were removed and thus CSRF can't work in the last release