### PR TITLE
🔧 Update default filename format

### DIFF
--- a/paperless-ngx/config.yaml
+++ b/paperless-ngx/config.yaml
@@ -28,7 +28,7 @@ map:
   - share:rw
   - ssl
 options:
-  filename: "{created_year}/{correspondent}/{title}"
+  filename: "{{ created_year }}/{{ correspondent }}/{{ title }}"
   language: eng
   language_packages: eng deu fra ita spa
   default_superuser:


### PR DESCRIPTION
Using the default config throws an error to the log:

```
WARNINGS:
?: Filename format {created_year}/{correspondent}/{title} is using the old style, please update to use double curly brackets
	HINT: {{ created_year }}/{{ correspondent }}/{{ title }}
System check identified 1 issue (0 silenced).
```

I propose to change it to the new style for new users (like myself).
Thanks for your work!