### PR TITLE
💚 Fix libpq version management and suppress Renovate no-result warnings

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,6 +47,11 @@
       "automerge": true
     },
     {
+      "description": "libpq5 and libpq-dev are not tracked separately in repology (they are binary packages from the postgresql-17 source). Version is managed via LIBPQ_VERSION in the Dockerfile.",
+      "matchDepNames": ["debian_13/libpq5", "debian_13/libpq-dev"],
+      "enabled": false
+    },
+    {
       "groupName": "Add-on base image",
       "matchDatasources": ["docker"]
     },

--- a/paperless-ngx/Dockerfile
+++ b/paperless-ngx/Dockerfile
@@ -28,6 +28,10 @@ ENV REDIS_VERSION="5:8.0.2-3+deb13u1"
 # renovate: datasource=repology depName=debian_13/zbar
 ENV LIBZBAR0_VERSION="0.23.93-8"
 
+# libpq5/libpq-dev are binary packages from postgresql-17 source; not tracked
+# separately in repology — update this value alongside POSTGRESQL_VERSION
+ENV LIBPQ_VERSION="17.10-0+deb13u1"
+
 # renovate: datasource=repology depName=debian_13/ghostscript
 ENV GHOSTSCRIPT_VERSION="10.05.1~dfsg-1+deb13u1"
 
@@ -50,7 +54,7 @@ ARG RUNTIME_PACKAGES="\
   icc-profiles-free=2.0.1+dfsg-1.1 \
   imagemagick=8:7.1.1.43+dfsg1-1+deb13u8 \
   # PostgreSQL
-  libpq5=17.10-0+deb13u1 \
+  libpq5=${LIBPQ_VERSION} \
   postgresql-client=${POSTGRESQL_VERSION} \
   # MySQL / MariaDB
   mariadb-client=1:11.8.6-0+deb13u1 \
@@ -140,7 +144,7 @@ ARG BUILD_PACKAGES="\
   build-essential \
   git \
   # https://www.psycopg.org/docs/install.html#prerequisites
-  libpq-dev=17.10-0+deb13u1 \
+  libpq-dev=${LIBPQ_VERSION} \
   # https://github.com/PyMySQL/mysqlclient#linux
   default-libmysqlclient-dev \
   pkg-config"


### PR DESCRIPTION
## Summary

- Extracts `LIBPQ_VERSION` as a single `ENV` variable, replacing two separate hardcoded `17.9-0+deb13u1` literals across `RUNTIME_PACKAGES` and `BUILD_PACKAGES`
- Adds a `packageRules` entry in `renovate.json` to explicitly disable `debian_13/libpq5` and `debian_13/libpq-dev` lookups that produce persistent **no-result** warnings in the Dependency Dashboard (issue #2)

## Root cause

`libpq5` and `libpq-dev` are binary packages from the `postgresql-17` source package and are **not tracked as standalone projects** in repology. Renovate's inline regex manager (the rule that scans `  package=version \` lines in `ARG` blocks) was auto-detecting them and generating:

```
⚠️ Failed to look up repology package debian_13/libpq5: no-result
⚠️ Failed to look up repology package debian_13/libpq-dev: no-result
```

The version was also duplicated — defined independently in two ARG blocks, making manual bumps error-prone.

## Changes

**`paperless-ngx/Dockerfile`**
- Add `ENV LIBPQ_VERSION="17.9-0+deb13u1"` alongside the other versioned ENV vars (`GNUPG_VERSION`, `GHOSTSCRIPT_VERSION`, etc.)
- Replace both hardcoded literals with `${LIBPQ_VERSION}` — variable references don't match the inline regex, so auto-detection stops automatically

**`.github/renovate.json`**
- Add a `packageRules` entry with `"enabled": false` for `debian_13/libpq5` and `debian_13/libpq-dev`, with a `description` explaining why, as belt-and-suspenders protection

> ⚠️ **Update note:** `LIBPQ_VERSION` should be bumped manually alongside `POSTGRESQL_VERSION` since both track the PostgreSQL 17.x upstream release cycle.

## Test plan

- [ ] Verify Docker build succeeds for both `amd64` and `aarch64`
- [ ] Confirm the Renovate Dependency Dashboard (issue #2) no longer shows the `libpq5` / `libpq-dev` no-result warnings after the next Renovate run

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgjYEbo1GRrkQuipkTh1gx)_