### PR TITLE
⬆️ Update debian_13/poppler to v25.03.0-5+deb13u3

### DIFF
--- a/paperless-ngx/Dockerfile
+++ b/paperless-ngx/Dockerfile
@@ -38,6 +38,9 @@ ENV GHOSTSCRIPT_VERSION="10.05.1~dfsg-1+deb13u1"
 # renovate: datasource=repology depName=debian_13/libxslt1 versioning=deb
 ENV LIBXSLT_VERSION="1.1.35-1.2+deb13u2"
 
+# renovate: datasource=repology depName=debian_13/poppler
+ENV POPPLER_VERSION="25.03.0-5+deb13u3"
+
 # Packages need for running
 ARG RUNTIME_PACKAGES="\
   # General utils
@@ -78,7 +81,7 @@ ARG RUNTIME_PACKAGES="\
   zlib1g=${ZLIB_VERSION} \
   # Barcode splitter
   libzbar0t64=${LIBZBAR0_VERSION} \
-  poppler-utils=25.03.0-5+deb13u2 \
+  poppler-utils=${POPPLER_VERSION} \
   python3=3.13.5-1 \
   python3-pip=25.1.1+dfsg-1 \
   python3-dev=3.13.5-1 \


### PR DESCRIPTION
## Summary

- `libpoppler147=25.03.0-5+deb13u2` was removed from the Debian trixie repos, causing `apt-get install` to fail with an unsatisfiable dependency conflict on every PR build
- Bumps `poppler-utils` from `25.03.0-5+deb13u2` → `25.03.0-5+deb13u3` to match the currently available package
- Adds a `# renovate:` tracking comment so Renovate will auto-bump poppler in future

## Root cause

`poppler-utils=25.03.0-5+deb13u2` has a hard dependency on `libpoppler147 (= 25.03.0-5+deb13u2)`, but that exact version of `libpoppler147` is no longer published in the Debian 13 repos (replaced by `deb13u3`). The APT solver therefore reported two conflicting decisions and aborted the build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DgjYEbo1GRrkQuipkTh1gx)_