### PR TITLE
🐛 Fix ingress SSO 403 lockout when no superuser exists

### DIFF
--- a/paperless-ngx/DOCS.md
+++ b/paperless-ngx/DOCS.md
@@ -57,10 +57,7 @@ url: http://example.com
 filename: "{created_year}/{correspondent}/{title}"
 language: eng
 language_packages: eng deu fra ita spa
-default_superuser:
-  username: admin
-  email: admin@example.com
-  password: changeme
+ingress_auth: false
 timezone: Europe/Paris
 polling_interval: 0
 barcodes_enabled: false
@@ -96,9 +93,25 @@ This can be a combination of multiple languages such as deu+eng, in which case t
 
 This is the list of language packages to install, separated by space
 
-### Option: `default_superuser`
+### Option: `ingress_auth`
 
-When the addon starts up, if this user is not created, it will create it.
+Enables SSO through Home Assistant Ingress: when opening Paperless-ngx from
+the sidebar, you are logged in automatically with your Home Assistant
+username and no password is asked.
+
+**First account**: Paperless-ngx offers to create the first account from its
+login screen as long as no account exists. Create it **using your Home
+Assistant username** so SSO matches your account, then restart the add-on.
+While no account exists, SSO stays deferred so this screen remains reachable.
+
+If the add-on ever created a permissionless SSO account before a superuser
+existed (the `403 Forbidden` symptom of older versions), that account is
+promoted to superuser automatically on the next add-on restart.
+
+**Note**: _An account created with a different username than your Home
+Assistant one will not be matched by SSO; Paperless-ngx would then create a
+separate account without permissions. A superuser can grant permissions to
+such accounts in `Settings > Users & Groups`._
 
 ### Option: `timezone`
 

--- a/paperless-ngx/rootfs/etc/s6-overlay/s6-rc.d/svc-ingress-webserver/run
+++ b/paperless-ngx/rootfs/etc/s6-overlay/s6-rc.d/svc-ingress-webserver/run
@@ -6,11 +6,64 @@
 # ==============================================================================
 
 # Set up the environment for the webserver
-export PAPERLESS_FORCE_SCRIPT_NAME=$(bashio::addon.ingress_entry)
-export PAPERLESS_ENABLE_HTTP_REMOTE_USER_API=$(bashio::config 'ingress_auth')
-export PAPERLESS_ENABLE_HTTP_REMOTE_USER=$(bashio::config 'ingress_auth')
+PAPERLESS_FORCE_SCRIPT_NAME=$(bashio::addon.ingress_entry)
+export PAPERLESS_FORCE_SCRIPT_NAME
 
-cd ${PAPERLESS_SRC_DIR}
+cd "${PAPERLESS_SRC_DIR}" || exit
+
+if bashio::config.true 'ingress_auth'; then
+    # Paperless only offers its first-account creation screen while no user
+    # exists. With SSO enabled, the remote-user middleware creates a
+    # permissionless user on the very first ingress request, which hides that
+    # screen forever and locks the user out with 403 errors (#306).
+    # Defer SSO until an account exists, and promote the single SSO-created
+    # user when it was left without permissions.
+    SSO_STATE=$(s6-setuidgid paperless python3 manage.py shell -c "
+from django.contrib.auth import get_user_model
+users = get_user_model().objects.exclude(username='AnonymousUser')
+if users.filter(is_superuser=True).exists():
+    print('ready')
+elif users.count() == 1:
+    user = users.first()
+    user.is_staff = True
+    user.is_superuser = True
+    user.save()
+    print('promoted:' + user.get_username())
+elif users.exists():
+    print('ambiguous')
+else:
+    print('no-user')
+" | tail -n1)
+
+    case "${SSO_STATE}" in
+        ready)
+            export PAPERLESS_ENABLE_HTTP_REMOTE_USER=true
+            export PAPERLESS_ENABLE_HTTP_REMOTE_USER_API=true
+            ;;
+        promoted:*)
+            bashio::log.warning "Ingress SSO: promoted '${SSO_STATE#promoted:}' to superuser," \
+                "this account was created by the ingress authentication while no superuser existed (#306)"
+            export PAPERLESS_ENABLE_HTTP_REMOTE_USER=true
+            export PAPERLESS_ENABLE_HTTP_REMOTE_USER_API=true
+            ;;
+        no-user)
+            bashio::log.notice "Ingress SSO is deferred until the first account exists:" \
+                "open Paperless-ngx, create the first account using your Home Assistant username," \
+                "then restart the add-on to enable SSO"
+            ;;
+        ambiguous)
+            bashio::log.warning "Ingress SSO: several accounts exist but none is a superuser," \
+                "grant superuser to one of them manually (see the add-on documentation)"
+            export PAPERLESS_ENABLE_HTTP_REMOTE_USER=true
+            export PAPERLESS_ENABLE_HTTP_REMOTE_USER_API=true
+            ;;
+        *)
+            bashio::log.warning "Ingress SSO: could not check the accounts state, enabling SSO anyway"
+            export PAPERLESS_ENABLE_HTTP_REMOTE_USER=true
+            export PAPERLESS_ENABLE_HTTP_REMOTE_USER_API=true
+            ;;
+    esac
+fi
 
 # Translate between things, preferring GRANIAN_
 export GRANIAN_HOST=${GRANIAN_HOST:-${PAPERLESS_BIND_ADDR:-"::"}}
@@ -23,4 +76,3 @@ if [[ -n "${PAPERLESS_FORCE_SCRIPT_NAME}" ]]; then
 fi
 
 exec s6-setuidgid paperless granian --interface asginl --ws --loop uvloop "paperless.asgi:application"
-

--- a/paperless-ngx/translations/en.yaml
+++ b/paperless-ngx/translations/en.yaml
@@ -16,9 +16,6 @@ configuration:
     name: Languages packs
     description: >-
       List of langages to install for OCR
-  default_superuser:
-    name: Default superuser
-    description: Superuser credentials
   timezone:
     name: Timezone
     description: Timezone
@@ -57,7 +54,11 @@ configuration:
     description: must match host GID of file owner
   ingress_auth:
     name: Enable Ingress authentication
-    description: This allow a SSO, when logged in to home assistant, login and password will not be asked
+    description: >-
+      This allow a SSO, when logged in to home assistant, login and password
+      will not be asked. Create the first account from the Paperless-ngx
+      login screen using your Home Assistant username, then restart the
+      add-on (see documentation)
   tika_gotenberg:
     name: Enable Tika Gotenberg
     description: You need to install the Tika Gotenberg addon


### PR DESCRIPTION
## Problem

Fixes #306 (and the likely root cause of the duplicate account in #293).

With `ingress_auth` enabled, the remote-user middleware auto-creates a **permissionless** user on the very first ingress request. Since Paperless-ngx only offers its first-account creation screen while no user exists, that screen is hidden forever and the user is permanently locked out with `403 Forbidden` on `/api/ui_settings/`. This matches all the field reports in #306 (it works when ingress auth is disabled *before* the first account is created).

## Solution

All the logic lives in `svc-ingress-webserver/run` (the DB is migrated at that point). When `ingress_auth` is enabled, the account state is checked at startup:

| State | Behaviour |
|---|---|
| A superuser exists | SSO enabled (unchanged behaviour) |
| No account at all | **SSO deferred** with a log notice: the upstream first-account screen stays reachable; SSO activates on the next restart |
| Exactly one account, no superuser | It is the SSO-created permissionless user → **promoted to superuser** (heals installations currently stuck at 403 with a simple restart) |
| Several accounts, no superuser | SSO enabled + warning, nobody is promoted (ambiguous) |
| Check fails (DB error…) | SSO enabled + warning (previous behaviour preserved) |

The django-guardian `AnonymousUser` row is excluded from all counts. Security-wise the promotion is equivalent to the upstream first-account screen ("first user becomes superuser"), except the user is already authenticated in Home Assistant.

Also:
- Removed the stale `default_superuser` option from `DOCS.md` and `translations/en.yaml` — it no longer exists in the schema and users in #306 were searching for it.
- Documented the `ingress_auth` first-account flow (use your Home Assistant username, then restart).
- Fixed pre-existing shellcheck warnings (SC2155, SC2164) in the touched script.

## Testing

Exercised the real `run` script end-to-end with `bashio`/`s6-setuidgid`/`granian` mocked and a real Django + sqlite database:

- fresh install, no account → SSO env vars not set, deferral notice logged
- only the guardian `AnonymousUser` row → still treated as "no account"
- stuck-at-403 install (single permissionless user) → user promoted (`is_staff`/`is_superuser` persisted in DB), SSO enabled
- second start on the same DB → idempotent, no double promotion
- superuser exists → SSO enabled, no warning
- several users, no superuser → SSO enabled + warning, nobody promoted
- `ingress_auth: false` → SSO env vars not set, no DB access
- unreachable DB → fallback: SSO enabled + warning

`shellcheck` and `yamllint` pass on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JT2QsdSaPh3amhtyc1wpy2

---
_Generated by [Claude Code](https://claude.ai/code/session_01JT2QsdSaPh3amhtyc1wpy2)_