### PR TITLE
🐛 Increase Nginx proxy timeouts to prevent 504 errors

### DIFF
--- a/paperless-ngx/rootfs/etc/nginx/templates/direct.gtpl
+++ b/paperless-ngx/rootfs/etc/nginx/templates/direct.gtpl
@@ -11,6 +11,12 @@ server {
         # Adjust host and port as required.
         proxy_pass http://localhost:8000/;
 
+        # Increase proxy timeouts to match LLM request timeout and avoid 504s
+        # (aligned with upstream LLM Request Timeout; 300s chosen to cover long inferences)
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+        proxy_connect_timeout 300s;
+
         # These configuration options are required for WebSockets to work.
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/paperless-ngx/rootfs/etc/nginx/templates/direct.gtpl
+++ b/paperless-ngx/rootfs/etc/nginx/templates/direct.gtpl
@@ -11,11 +11,10 @@ server {
         # Adjust host and port as required.
         proxy_pass http://localhost:8000/;
 
-        # Increase proxy timeouts to match LLM request timeout and avoid 504s
-        # (aligned with upstream LLM Request Timeout; 300s chosen to cover long inferences)
-        proxy_read_timeout 300s;
-        proxy_send_timeout 300s;
-        proxy_connect_timeout 300s;
+        # Allow long-running requests such as local AI inference to complete.
+        # Keep the proxy timeout slightly above Paperless' default LLM request timeout.
+        proxy_read_timeout 330s;
+        proxy_send_timeout 330s;
 
         # These configuration options are required for WebSockets to work.
         proxy_http_version 1.1;

--- a/paperless-ngx/rootfs/etc/nginx/templates/ingress.gtpl
+++ b/paperless-ngx/rootfs/etc/nginx/templates/ingress.gtpl
@@ -7,6 +7,11 @@ server {
         # Adjust host and port as required.
         proxy_pass http://localhost:8001/;
 
+        # Allow long-running requests such as local AI inference to complete.
+        # Keep the proxy timeout slightly above Paperless' default LLM request timeout.
+        proxy_read_timeout 330s;
+        proxy_send_timeout 330s;
+
         # These configuration options are required for WebSockets to work.
         proxy_http_version 1.1;
         proxy_set_header Accept-Encoding "";


### PR DESCRIPTION
Increase Nginx proxy timeouts to allow long-running requests such as
local LLM inference to complete.

The default Nginx proxy_read_timeout is 60 seconds, which causes AI
suggestion requests to return 504 while Paperless is still waiting for
the configured LLM backend.

Set the proxy timeout slightly above Paperless' default 300-second LLM
request timeout so Paperless can own and return the timeout itself.
Apply the same behavior to direct access and Home Assistant Ingress.